### PR TITLE
split provision script into checkout and after checkout parts

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -16,14 +16,9 @@ if [ $? -ne 0 ]; then
   fi
 fi
 
-ruby_version=`cat .ruby-version`
-echo Installing Ruby $ruby_version
-source /home/ubuntu/rbenv-init && rbenv install -s $ruby_version
+# Wrap the remaining calls inside another script so that we get the checkedout
+# version of the script.
 
-echo Installing bundler
-gem install --conservative bundler
+# TODO only call it if the checkout changed the SHA
 
-echo Installing gems
-bundle install
-
-echo Done!
+./provision_after_checkout.sh

--- a/provision_after_checkout.sh
+++ b/provision_after_checkout.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+ruby_version=`cat .ruby-version`
+echo Installing Ruby $ruby_version
+source /home/ubuntu/rbenv-init && rbenv install -s $ruby_version
+
+echo Installing bundler
+gem install --conservative bundler
+
+echo Installing gems
+bundle install
+
+echo Done!


### PR DESCRIPTION
The original clone during image building uses master.  This change leaves the unchanging part of updating an image's code in the provision.sh script and moves the rest into a different script that is more free to change.