### PR TITLE
Validation and logic for different assessment versions

### DIFF
--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -1,7 +1,6 @@
 # coding: utf-8
 class Assessment < ApplicationRecord
 
-  belongs_to :format
   belongs_to :member
   has_many :questions, inverse_of: :assessment
   has_many :other_versions,

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -2,13 +2,31 @@
 class Assessment < ApplicationRecord
 
   belongs_to :format
-  belongs_to :created_by, class_name: 'Member'
+  belongs_to :member
+  has_many :questions, inverse_of: :assessment
+  has_many :other_versions,
+           -> (a) { where.not(id: a.id) },
+           class_name: 'Assessment',
+           foreign_key: :identifier, primary_key: :identifier
+
 
   enum visibility: %i[internal external]
 
-  has_many :questions, inverse_of: :assessment
-  validates :format, :created_by, presence: true
-
   validates :version, uniqueness: { scope: :identifier }
+
+  before_validation :set_version, on: :create
+  validate :ensure_member_matches_other_versions
+
+  protected
+
+  def set_version
+    self.version = other_versions.size + 1
+  end
+
+  def ensure_member_matches_other_versions
+    if other_versions.any? && member_id != other_versions.last.member_id
+      errors.add(:member, 'must be the same as other versions')
+    end
+  end
 
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -2,10 +2,10 @@ class Question < ApplicationRecord
 
   belongs_to :assessment
   belongs_to :format
-  belongs_to :created_by, class_name: 'Member'
   has_many :solutions, inverse_of: :question, dependent: :destroy
   has_many :assets, as: :owner, dependent: :destroy
-  validates :content, :created_by, :format, presence: true
+
+  validates :content, presence: true
   validates :assessment, presence: true
   # the variant id may be left blank unless the assessment has multiple questions
   validates :variant_id, uniqueness: { scope: :assessment }, allow_blank: true

--- a/app/models/solution.rb
+++ b/app/models/solution.rb
@@ -2,7 +2,7 @@ class Solution < ApplicationRecord
 
   belongs_to :question
   belongs_to :format
-  belongs_to :created_by, class_name: 'Member'
+  belongs_to :member
   has_many :assets, as: :owner
 
   validates :content, :format, presence: true

--- a/app/serializers/api/v1/assessment_serializer.rb
+++ b/app/serializers/api/v1/assessment_serializer.rb
@@ -42,7 +42,7 @@ module Api
                type: :string,
                format: 'Date'
 
-      property :created_by, document: false, readable: false,
+      property :member, document: false, readable: false,
                reader: ->(user_options:, **) {
         new_record? ? user_options[:current_member] : nil
       }

--- a/app/serializers/api/v1/assessment_serializer.rb
+++ b/app/serializers/api/v1/assessment_serializer.rb
@@ -6,7 +6,7 @@ module Api
 
       swagger_schema :Assessment do
         key :description, "The umbrella record for all things related to an exercises that a student could work, including its stem, answer, solutions, and variants"
-        key :required, [:id, :version, :visibility, :format_id, :content, :created_at]
+        key :required, [:id, :version, :visibility, :content, :created_at]
         property :id,           type: :string, format: :uuid
         property :created_at,   type: :string, format: 'date-time'
       end
@@ -32,11 +32,6 @@ module Api
       property :preview_html,
                type: :string,
                description: 'If provided, will be used to generate a preview on the a15k website'
-
-      property :format_id,
-               type: :string,
-               format: :uuid,
-               description: 'The uuid of a previously registered format'
 
       property :created_at,
                type: :string,

--- a/app/serializers/api/v1/question_serializer.rb
+++ b/app/serializers/api/v1/question_serializer.rb
@@ -33,11 +33,6 @@ module Api
       property :content,    type: :string,
                description: "The content of the question. The formatting the the content is indicated by the assessment's linked format"
 
-      property :created_by, document: false, readable: false,
-               reader: ->(user_options:, **) {
-        new_record? ? user_options[:current_member] : nil
-      }
-
       property :solutions, collection: true, extend: SolutionSerializer, class: Solution do |doc|
         doc.key :type, :array
         doc.items do

--- a/app/serializers/api/v1/solution_serializer.rb
+++ b/app/serializers/api/v1/solution_serializer.rb
@@ -22,7 +22,7 @@ module Api
 
       property :format_id, type: :string, format: :uuid, description: 'The uuid of a previously registered format'
 
-      property :created_by, document: false, readable: false,
+      property :member, document: false, readable: false,
                reader: ->(user_options:, **) {
         new_record? ? user_options[:current_member] : nil
       }

--- a/db/migrate/20180206164740_create_assessments.rb
+++ b/db/migrate/20180206164740_create_assessments.rb
@@ -3,11 +3,11 @@ class CreateAssessments < ActiveRecord::Migration[5.1]
 
     create_table :assessments, id: :uuid do |t|
       t.string :identifier, index: true
+      t.belongs_to :member, type: :uuid, null: false, foreign_key: true
       t.string :version, null: false, index: true, default: '1'
       t.integer :visibility, limit: 2 # smallint
       t.belongs_to :format, type: :uuid, null: false, foreign_key: true
       t.text :preview_html
-      t.belongs_to :created_by, type: :uuid, null: false, foreign_key: { to_table: :members }
       t.timestamp :created_at, null: false, index: true
     end
 

--- a/db/migrate/20180206164740_create_assessments.rb
+++ b/db/migrate/20180206164740_create_assessments.rb
@@ -4,11 +4,12 @@ class CreateAssessments < ActiveRecord::Migration[5.1]
     create_table :assessments, id: :uuid do |t|
       t.string :identifier, index: true
       t.belongs_to :member, type: :uuid, null: false, foreign_key: true
-      t.string :version, null: false, index: true, default: '1'
+      t.integer :version, null: false, default: 1
       t.integer :visibility, limit: 2 # smallint
       t.text :preview_html
       t.timestamp :created_at, null: false, index: true
     end
 
+    add_index :assessments, [:identifier, :version], unique: true
   end
 end

--- a/db/migrate/20180206164740_create_assessments.rb
+++ b/db/migrate/20180206164740_create_assessments.rb
@@ -6,7 +6,6 @@ class CreateAssessments < ActiveRecord::Migration[5.1]
       t.belongs_to :member, type: :uuid, null: false, foreign_key: true
       t.string :version, null: false, index: true, default: '1'
       t.integer :visibility, limit: 2 # smallint
-      t.belongs_to :format, type: :uuid, null: false, foreign_key: true
       t.text :preview_html
       t.timestamp :created_at, null: false, index: true
     end

--- a/db/migrate/20180321160325_create_questions.rb
+++ b/db/migrate/20180321160325_create_questions.rb
@@ -5,7 +5,6 @@ class CreateQuestions < ActiveRecord::Migration[5.1]
       t.belongs_to :format, type: :uuid, null: false, foreign_key: true
       t.text :content, null: false
       t.text :variant_id, index: true
-      t.belongs_to :created_by, type: :uuid, null: false, foreign_key: { to_table: :members }
       t.timestamp :created_at, null: false
     end
   end

--- a/db/migrate/20180321160334_create_solutions.rb
+++ b/db/migrate/20180321160334_create_solutions.rb
@@ -4,7 +4,7 @@ class CreateSolutions < ActiveRecord::Migration[5.1]
       t.belongs_to :question, type: :uuid, null: false, foreign_key: true
       t.belongs_to :format, type: :uuid, null: false, foreign_key: true
       t.text :content, null: false
-      t.belongs_to :created_by, type: :uuid, null: false, foreign_key: { to_table: :members }
+      t.belongs_to :member, type: :uuid, null: false, foreign_key: true
       t.timestamp :created_at, null: false
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -27,16 +27,16 @@ ActiveRecord::Schema.define(version: 2018_05_16_193738) do
 
   create_table "assessments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "identifier"
+    t.uuid "member_id", null: false
     t.string "version", default: "1", null: false
     t.integer "visibility", limit: 2
     t.uuid "format_id", null: false
     t.text "preview_html"
-    t.uuid "created_by_id", null: false
     t.datetime "created_at", null: false
     t.index ["created_at"], name: "index_assessments_on_created_at"
-    t.index ["created_by_id"], name: "index_assessments_on_created_by_id"
     t.index ["format_id"], name: "index_assessments_on_format_id"
     t.index ["identifier"], name: "index_assessments_on_identifier"
+    t.index ["member_id"], name: "index_assessments_on_member_id"
     t.index ["version"], name: "index_assessments_on_version"
   end
 
@@ -146,10 +146,8 @@ ActiveRecord::Schema.define(version: 2018_05_16_193738) do
     t.uuid "format_id", null: false
     t.text "content", null: false
     t.text "variant_id"
-    t.uuid "created_by_id", null: false
     t.datetime "created_at", null: false
     t.index ["assessment_id"], name: "index_questions_on_assessment_id"
-    t.index ["created_by_id"], name: "index_questions_on_created_by_id"
     t.index ["format_id"], name: "index_questions_on_format_id"
     t.index ["variant_id"], name: "index_questions_on_variant_id"
   end
@@ -158,10 +156,10 @@ ActiveRecord::Schema.define(version: 2018_05_16_193738) do
     t.uuid "question_id", null: false
     t.uuid "format_id", null: false
     t.text "content", null: false
-    t.uuid "created_by_id", null: false
+    t.uuid "member_id", null: false
     t.datetime "created_at", null: false
-    t.index ["created_by_id"], name: "index_solutions_on_created_by_id"
     t.index ["format_id"], name: "index_solutions_on_format_id"
+    t.index ["member_id"], name: "index_solutions_on_member_id"
     t.index ["question_id"], name: "index_solutions_on_question_id"
   end
 
@@ -185,14 +183,13 @@ ActiveRecord::Schema.define(version: 2018_05_16_193738) do
 
   add_foreign_key "access_tokens", "members"
   add_foreign_key "assessments", "formats"
-  add_foreign_key "assessments", "members", column: "created_by_id"
+  add_foreign_key "assessments", "members"
   add_foreign_key "assets", "members", column: "created_by_id"
   add_foreign_key "formats", "members", column: "created_by_id"
   add_foreign_key "questions", "assessments"
   add_foreign_key "questions", "formats"
-  add_foreign_key "questions", "members", column: "created_by_id"
   add_foreign_key "solutions", "formats"
-  add_foreign_key "solutions", "members", column: "created_by_id"
+  add_foreign_key "solutions", "members"
   add_foreign_key "solutions", "questions"
   add_foreign_key "translators", "formats", column: "input_id"
   add_foreign_key "translators", "formats", column: "output_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -28,14 +28,14 @@ ActiveRecord::Schema.define(version: 2018_05_16_193738) do
   create_table "assessments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "identifier"
     t.uuid "member_id", null: false
-    t.string "version", default: "1", null: false
+    t.integer "version", default: 1, null: false
     t.integer "visibility", limit: 2
     t.text "preview_html"
     t.datetime "created_at", null: false
     t.index ["created_at"], name: "index_assessments_on_created_at"
+    t.index ["identifier", "version"], name: "index_assessments_on_identifier_and_version", unique: true
     t.index ["identifier"], name: "index_assessments_on_identifier"
     t.index ["member_id"], name: "index_assessments_on_member_id"
-    t.index ["version"], name: "index_assessments_on_version"
   end
 
   create_table "assets", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,11 +30,9 @@ ActiveRecord::Schema.define(version: 2018_05_16_193738) do
     t.uuid "member_id", null: false
     t.string "version", default: "1", null: false
     t.integer "visibility", limit: 2
-    t.uuid "format_id", null: false
     t.text "preview_html"
     t.datetime "created_at", null: false
     t.index ["created_at"], name: "index_assessments_on_created_at"
-    t.index ["format_id"], name: "index_assessments_on_format_id"
     t.index ["identifier"], name: "index_assessments_on_identifier"
     t.index ["member_id"], name: "index_assessments_on_member_id"
     t.index ["version"], name: "index_assessments_on_version"
@@ -182,7 +180,6 @@ ActiveRecord::Schema.define(version: 2018_05_16_193738) do
   end
 
   add_foreign_key "access_tokens", "members"
-  add_foreign_key "assessments", "formats"
   add_foreign_key "assessments", "members"
   add_foreign_key "assets", "members", column: "created_by_id"
   add_foreign_key "formats", "members", column: "created_by_id"

--- a/spec/clients/ruby_spec.rb
+++ b/spec/clients/ruby_spec.rb
@@ -30,7 +30,6 @@ describe 'Ruby client', type: :api do
 
     it 'can be created' do
       response = api_instance.create_assessment(
-        format_id: format.id,
         identifier: 'TEST-Test-AND-TEST-MORE',
         content: { text: Faker::Lorem.paragraph }.to_json,
         questions: 2.times.map{|question_index|
@@ -56,7 +55,6 @@ describe 'Ruby client', type: :api do
       expect(response.data).to be_a_kind_of(A15kClient::Assessment)
       assessment = response.data
       expect(assessment.identifier).to eq('TEST-Test-AND-TEST-MORE')
-      expect(assessment.format_id).to eq(format.id)
       expect(assessment.questions.length).to eq(2)
       expect(assessment.questions[0].solutions.length).to eq(1)
     end

--- a/spec/factories/assessments.rb
+++ b/spec/factories/assessments.rb
@@ -1,17 +1,21 @@
 FactoryBot.define do
   factory :assessment do
-    format
 
     identifier { SecureRandom.uuid }
     association :member, factory: :member
 
     visibility { :internal }
 
-    after(:create) do |asm|
-      if asm.questions.none?
-        asm.questions << FactoryBot.create(:question, assessment: asm, format: asm.format)
-      end
+    transient do
+      format { FactoryBot.create(:format) }
+    end
 
+    after(:create) do |asm, evaluator|
+      if asm.questions.none?
+        asm.questions << FactoryBot.create(:question,
+                                           assessment: asm,
+                                           format: evaluator.format)
+      end
     end
 
   end

--- a/spec/factories/assessments.rb
+++ b/spec/factories/assessments.rb
@@ -3,7 +3,8 @@ FactoryBot.define do
     format
 
     identifier { SecureRandom.uuid }
-    association :created_by, factory: :member
+    association :member, factory: :member
+
     visibility { :internal }
 
     after(:create) do |asm|

--- a/spec/factories/questions.rb
+++ b/spec/factories/questions.rb
@@ -6,7 +6,6 @@ FactoryBot.define do
 
     format
     content { Faker::Hacker.say_something_smart }
-    association :created_by, factory: :member
 
     transient do
       solutions_count 1

--- a/spec/factories/solutions.rb
+++ b/spec/factories/solutions.rb
@@ -3,6 +3,6 @@ FactoryBot.define do
     question
     format
     content { Faker::Hacker.say_something_smart }
-    association :created_by, factory: :member
+    association :member, factory: :member
   end
 end

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -1,8 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe Assessment, type: :model do
-  it "has working factory" do
-    asm = FactoryBot.create :assessment
-    expect(asm.questions.count).to eq 1
+  let(:member) { FactoryBot.create :member }
+  let(:assessment) { FactoryBot.create :assessment, member: member, identifier: '1234' }
+
+  it 'tracks versions' do
+    other = FactoryBot.create :assessment, member: member, identifier: '1234'
+    versions = assessment.other_versions.reload
+    expect(versions).not_to include assessment
+    expect(versions).to include other
   end
+
+  it 'disallows other members from making new versions' do
+    other_member = FactoryBot.create :member
+    other = Assessment.new(
+      identifier: '1234',
+      member: other_member,
+      format: assessment.format
+    )
+    expect(other.save).to be false
+    expect(other.errors[:member]).to include 'must be the same as other versions'
+  end
+
 end

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -14,10 +14,10 @@ RSpec.describe Assessment, type: :model do
   it 'disallows other members from making new versions' do
     other_member = FactoryBot.create :member
     other = Assessment.new(
-      identifier: '1234',
-      member: other_member,
-      format: assessment.format
+      identifier: assessment.identifier,
+      member: other_member
     )
+    expect(other.other_versions.size).to eq 1
     expect(other.save).to be false
     expect(other.errors[:member]).to include 'must be the same as other versions'
   end

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe Assessment, type: :model do
   let(:assessment) { FactoryBot.create :assessment, member: member, identifier: '1234' }
 
   it 'tracks versions' do
-    expect(assessment.version).to eq '1'
+    expect(assessment.version).to eq 1
     other = FactoryBot.create :assessment, member: member, identifier: '1234'
-    expect(other.version).to eq '2'
+    expect(other.version).to eq 2
     versions = assessment.other_versions.reload
     expect(versions).not_to include assessment
     expect(versions).to include other

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -5,7 +5,9 @@ RSpec.describe Assessment, type: :model do
   let(:assessment) { FactoryBot.create :assessment, member: member, identifier: '1234' }
 
   it 'tracks versions' do
+    expect(assessment.version).to eq '1'
     other = FactoryBot.create :assessment, member: member, identifier: '1234'
+    expect(other.version).to eq '2'
     versions = assessment.other_versions.reload
     expect(versions).not_to include assessment
     expect(versions).to include other

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -13,6 +13,12 @@ RSpec.describe Assessment, type: :model do
     expect(versions).to include other
   end
 
+  it 'has versions that only belong to the same identifier' do
+    other_member = FactoryBot.create :member
+    other_assment = FactoryBot.create :assessment, member: other_member
+    expect(assessment.other_versions).to be_empty
+  end
+
   it 'disallows other members from making new versions' do
     other_member = FactoryBot.create :member
     other = Assessment.new(

--- a/spec/requests/assessments_spec.rb
+++ b/spec/requests/assessments_spec.rb
@@ -58,7 +58,6 @@ describe 'Assessments API', type: :request do
         post "/api/v1/assessments.json", params: {
                identifier: SecureRandom.uuid,
                content: '1234 this is content',
-               format_id: format.id,
                questions: [
                  {
                    format_id: format.id,
@@ -88,36 +87,34 @@ describe 'Assessments API', type: :request do
       it 'can create multiple versions' do
         id = SecureRandom.uuid
         post "/api/v1/assessments.json", params: {
-               identifier: id, version: '1', format_id: format.id,
+               identifier: id, version: '1',
                questions: [{ format_id: format.id, content: '1st' }]
              }.to_json, headers: headers
         expect(response).to be_ok
 
         post "/api/v1/assessments.json", params: {
-               identifier: id, version: '2', format_id: format.id,
+               identifier: id, version: '2',
                questions: [{ format_id: format.id, content: '1st' }]
              }.to_json, headers: headers
         expect(response).to be_ok
         expect(Assessment.where(identifier: id).count).to eq 2
       end
 
-      it 'fails if version is taken' do
-        asm = FactoryBot.create :assessment, version: '1', identifier: '1'
+      it 'fails if member is different' do
+        asm = FactoryBot.create :assessment, identifier: '1'
         post "/api/v1/assessments.json", params: {
                identifier: asm.identifier, version: asm.version,
-               format_id: asm.format_id,
                questions: [{ format_id: format.id, content: '1st' }]
              }.to_json, headers: headers
         expect(response.status).to eq 422
         expect(response_json['success']).to be false
-        expect(response_json['message']).to include 'Version has already been taken'
+        expect(response_json['message']).to include 'Member must be the same'
       end
     end
     it 'can create a generative assessments' do
       expect {
         post "/api/v1/assessments.json", params: {
                identifier: SecureRandom.uuid,
-               format_id: format.id,
                questions: (1..20).flat_map do |a|
                  (1..10).map do |b|
                    {
@@ -142,7 +139,6 @@ describe 'Assessments API', type: :request do
     it 'errors when variants are not correct' do
         post "/api/v1/assessments.json", params: {
                identifier: SecureRandom.uuid,
-               format_id: format.id,
                questions: [
                  { format_id: format.id, content: '1st' },
                  { format_id: format.id, content: '2nd' },


### PR DESCRIPTION
* Auto-increment the version # of an assessment
* Require all version to have the same owner
* Remove the format from assessments since it wasn't being used
* Specs for the above