### PR TITLE
add member name to users screen

### DIFF
--- a/app/javascript/models/config.js
+++ b/app/javascript/models/config.js
@@ -5,10 +5,12 @@ export class Config {
 
   @observable token;
   @observable csrf_token;
+  @observable member_name;
 
   @action.bound bootstrap(data) {
     this.jwt = data.token;
     this.csrf_token = read_csrf();
+    this.member_name = data.member_name;
   }
 
 }

--- a/app/javascript/pages/users.js
+++ b/app/javascript/pages/users.js
@@ -3,6 +3,7 @@ import { Redirect } from 'react-router-dom';
 import Button from '../components/button';
 import { React, ModelCollectionType, observer, observable, action } from '../helpers/react';
 import User from '../models/user';
+import Config from '../models/config';
 import ErrorDisplay from '../components/model-errors';
 import styled from 'styled-components';
 import UserRow from './users/user';
@@ -57,9 +58,9 @@ export default class Users extends React.Component {
 
     return (
       <div className="access-users">
-        <h1>
-          Users
-        </h1>
+        <h2>
+          Users for member {Config.member_name}
+        </h2>
 
         <div className="d-flex justify-content-end">
           PowerUser?

--- a/app/views/home/application.html.erb
+++ b/app/views/home/application.html.erb
@@ -3,6 +3,7 @@
       user: current_user,
       interactions_api_url: Rails.application.secrets.interactions_api[:url],
       token: current_user.membership_access_token,
+      member_name: current_user.member.name,
       }.to_json.html_safe %>
 </script>
 <%= javascript_pack_tag('application') unless current_user.anonymous? %>

--- a/spec/javascript/pages/__snapshots__/users.spec.js.snap
+++ b/spec/javascript/pages/__snapshots__/users.spec.js.snap
@@ -4,9 +4,10 @@ exports[`Users renders listing 1`] = `
 <div
   className="access-users"
 >
-  <h1>
-    Users
-  </h1>
+  <h2>
+    Users for member 
+    Illuminati
+  </h2>
   <div
     className="d-flex justify-content-end"
   >

--- a/spec/javascript/pages/users.spec.js
+++ b/spec/javascript/pages/users.spec.js
@@ -6,7 +6,9 @@ import User from 'models/user';
 jest.mock('models/user', () => ({
   id: 1,
 }));
-
+jest.mock('models/config', () => ({
+  member_name: 'Illuminati',
+}));
 jest.mock('pages/users/delete-placeholder', () => {
   return () => <div className="delete-placeholder" />;
 });


### PR DESCRIPTION
This way it's clear that the users shown are only for the current member

![screen shot 2018-07-17 at 3 35 47 pm](https://user-images.githubusercontent.com/79566/42843911-187ef712-89d7-11e8-94dc-68fcf4775211.png)

