### PR TITLE
alternative demo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,8 @@ gem "openstax_healthcheck"
 # For getting secrets from AWS Parameter Store
 gem "aws-sdk-ssm"
 
+gem 'faker' # Lorem Ipsum
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
@@ -59,7 +61,6 @@ group :development, :test do
   gem 'factory_bot_rails'
   gem 'dotenv-rails'
   gem 'guard-rspec', require: false
-  gem 'faker' # Lorem Ipsum
 end
 
 group :development do

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -22,7 +22,7 @@ development:
   base_url: a15k.org
   secret_key_base: <%= ENV.fetch('SECRET_KEY_BASE', 'af8b9fab193891504598d3720c18c3109c4756fd6c3dc53c01d683b02d649cb384cc0fd6dac3f1812939bde7c9634b2633833cf209a9b11a13c0bf3c9cd00404') %>
   metadata_api:
-    url: http://localhost:3000
+    url: http://localhost:4002
     token: <%= ENV['A15K_METADATA_TOKEN'] || 'a15k_insecure_token' %>
     application_uuid: <%= ENV['A15K_METADATA_APP_UUID'] %>
     stub: <%= ENV.fetch('A15K_METADATA_STUB', true) %>

--- a/lib/demo/member_a.rb
+++ b/lib/demo/member_a.rb
@@ -1,0 +1,152 @@
+require_relative 'utils'
+
+module Demo2
+  class MemberA
+
+    PHYSICS_KEYWORDS = ['vector', 'velocity', 'mass']
+
+    attr_reader :member
+
+    def initialize(member_name:)
+      @member = Member.create(name: member_name, website: Faker::Internet.url(nil, '/'))
+    end
+
+    MC_TEMPLATE = ERB.new(Pathname.new(__FILE__).dirname.join('member_a_mc.html.erb').read)
+
+    def generate_multiple_choice(keyword: nil, tags: [])
+      correct_index = [*0..3].shuffle.sample
+      question_content = {
+        stem: Demo2::Utils.sentence +
+              Demo2::Utils.sentence(question: true, keyword: keyword || PHYSICS_KEYWORDS.sample),
+        answers: 4.times.map do |ii|
+          {
+            content: Demo2::Utils.sentence,
+            score: ii == correct_index ? 1.0 : 0.0
+          }
+        end
+      }
+
+      solution = Demo2::Utils.sentence
+
+      Assessment.create(
+        questions: [
+          Question.new(
+            format_id: multiple_choice_format.id,
+            content: question_content.to_json,
+            solutions: [
+              Solution.new(
+                format_id: plain_text_format.id,
+                content: solution,
+                member: member
+              )
+            ]
+          )
+        ],
+        preview_html: MC_TEMPLATE.result(binding),
+        member: member
+      )
+    end
+
+    FITB_TEMPLATE = ERB.new(Pathname.new(__FILE__).dirname.join('member_a_fitb.html.erb').read)
+
+    def generate_fill_in_the_blank(keyword: nil, tags: [])
+      question_content = {
+        stem: Demo2::Utils.sentence(keyword: keyword || PHYSICS_KEYWORDS.sample, blank: true),
+      }
+
+      solution = Faker::Lorem.word
+
+      Assessment.create(
+        questions: [
+          Question.new(
+            format_id: fill_in_the_blank_format.id,
+            content: question_content.to_json,
+            solutions: [
+              Solution.new(
+                format_id: plain_text_format.id,
+                content: solution,
+                member: member
+              )
+            ]
+          )
+        ],
+        preview_html: FITB_TEMPLATE.result(binding),
+        member: member
+      )
+    end
+
+    SHORT_TEMPLATE = ERB.new(Pathname.new(__FILE__).dirname.join('member_a_short.html.erb').read)
+
+    def generate_short_answer(keyword: nil, tags: [])
+      question_content = {
+        stem: Demo2::Utils.sentence(keyword: keyword || PHYSICS_KEYWORDS.sample, question: true),
+      }
+
+      solution = Demo2::Utils.sentence
+
+      Assessment.create(
+        questions: [
+          Question.new(
+            format_id: fill_in_the_blank_format.id,
+            content: question_content.to_json,
+            solutions: [
+              Solution.new(
+                format_id: plain_text_format.id,
+                content: solution,
+                member: member
+              )
+            ]
+          )
+        ],
+        preview_html: SHORT_TEMPLATE.result(binding),
+        member: member
+      )
+    end
+
+    def multiple_choice_format
+      identifier = member.name + "_mc"
+      Format.find_by(identifier: identifier) || Format.create!(
+        identifier: identifier,
+        name: member.name + " multiple choice",
+        specification: "A document that describes all you need to know about #{member.name}'s multiple choice data format.",
+        created_by: member
+      )
+    end
+
+    def fill_in_the_blank_format
+      identifier = member.name + "_fitb"
+      Format.find_by(identifier: identifier) || Format.create!(
+        identifier: identifier,
+        name: member.name + " fill-in-the-blank",
+        specification: "A document that describes all you need to know about #{member.name}'s fill-in-the-blank data format.",
+        created_by: member
+      )
+    end
+
+    def short_answer_format
+      identifier = member.name + "_short"
+      Format.find_by(identifier: identifier) || Format.create!(
+        identifier: identifier,
+        name: member.name + " short answer",
+        specification: "A document that describes all you need to know about #{member.name}'s short answer data format.",
+        created_by: member
+      )
+    end
+
+    def plain_text_format
+      identifier = member.name + "_plain"
+      Format.find_by(identifier: identifier) || Format.create!(
+        identifier: identifier,
+        name: member.name + " plain text",
+        specification: "A document that describes all you need to know about #{member.name}'s plain text data format.",
+        created_by: member
+      )
+    end
+
+    def nl2br(text)
+      text.gsub("\n", '<br>')
+    end
+
+  end
+
+end

--- a/lib/demo/member_a_fitb.html.erb
+++ b/lib/demo/member_a_fitb.html.erb
@@ -1,0 +1,10 @@
+<div class="demo-assessment">
+  <h4 class="question"><%= nl2br question_content[:stem] %></h4>
+
+  <h4>Solutions</h4>
+  <ul>
+  <li class="solution">
+    <%= nl2br solution %>
+  </li>
+  </ul>
+</div>

--- a/lib/demo/member_a_mc.html.erb
+++ b/lib/demo/member_a_mc.html.erb
@@ -1,0 +1,29 @@
+<div class="demo-assessment">
+  <h4 class="question"><%= nl2br question_content[:stem] %></h4>
+
+<% unless question_content[:answers].empty? %>
+  <div class="answer_choices">
+    <% answer_letter_code = "a".ord-1 %>
+    <table width="100%">
+      <% question_content[:answers].each do |ac| %>
+        <tr>
+          <td class="answer_choice_index" width="5%">
+            <p><%= (answer_letter_code += 1).chr %>)</p>
+          </td>
+          <td class="answer_choice" width="95%">
+            <%= ac[:content].html_safe %> <% if ac[:score] == 1.0 %>✅<% end %>
+          </td>
+        </tr>
+      <% end %>
+    </table>
+  </div>
+<% end %>
+
+<h4>Solutions</h4>
+  <ul>
+
+  <li class="solution">
+    <%= nl2br solution %>
+  </li>
+  </ul>
+</div>

--- a/lib/demo/member_a_short.html.erb
+++ b/lib/demo/member_a_short.html.erb
@@ -1,0 +1,11 @@
+<div class="demo-assessment">
+  <h4 class="question"><%= nl2br question_content[:stem] %></h4>
+
+  <h4>Solutions</h4>
+  <ul>
+
+  <li class="solution">
+    <%= nl2br solution %>
+  </li>
+  </ul>
+</div>

--- a/lib/demo/utils.rb
+++ b/lib/demo/utils.rb
@@ -1,0 +1,31 @@
+module Demo2
+  module Utils
+
+    def self.sentence(keyword: nil, question: false, blank: false)
+      value = Faker::Lorem.sentence(12, true, 3)
+      value[-1] = ''
+
+      if keyword.present? || blank
+        words = value.split
+        indexes = [*0..words.length-1].shuffle
+
+        if keyword.present?
+          keyword_index = indexes.pop
+          words[keyword_index] = keyword
+        end
+
+        if blank
+          blank_index = indexes.pop
+          words[blank_index] = "_________"
+        end
+
+        value = words.join(" ")
+      end
+
+      value.capitalize!
+      value + (question ? '? ' : '. ')
+    end
+
+
+  end
+end

--- a/lib/tasks/demo2.rake
+++ b/lib/tasks/demo2.rake
@@ -1,0 +1,26 @@
+require_relative '../demo/member_a'
+
+desc <<-DESC.strip_heredoc
+  Generate demo2 data
+DESC
+task :demo2, [] => :environment do |tt,args|
+
+  demo_member_a = Demo2::MemberA.new(member_name: "OpenStax")
+
+  [
+    %w[ox standard_user],
+    %w[ox_power_user power_user]
+  ].each do |username, role|
+    account = ::OpenStax::Accounts::FindOrCreateAccount.call(
+      email: 'support@openstax.org', username: username, password: 'password'
+    ).outputs.account
+    User.create!(
+      member_id: demo_member_a.member.id, account_id: account.id, role: role
+    )
+  end
+
+  7.times { demo_member_a.generate_multiple_choice }
+  4.times { demo_member_a.generate_fill_in_the_blank }
+  8.times { demo_member_a.generate_short_answer }
+
+end

--- a/spec/lib/demo2_spec.rb
+++ b/spec/lib/demo2_spec.rb
@@ -1,0 +1,25 @@
+require_relative '../rails_helper'
+require_relative '../../lib/demo/member_a'
+
+describe 'Demo data' do
+
+  let(:demo_member) { Demo2::MemberA.new(member_name: "OpenStax") }
+
+  it 'generates a short answer assessment' do
+    expect{
+      demo_member.generate_short_answer
+    }.to change{ Assessment.count }
+  end
+
+  it 'generates a multiple choice assessment' do
+    expect{
+      demo_member.generate_multiple_choice
+    }.to change{ Assessment.count }
+  end
+
+  it 'generates a fill in the blank assessment' do
+    expect{
+      demo_member.generate_fill_in_the_blank
+    }.to change{ Assessment.count }
+  end
+end


### PR DESCRIPTION
Alternative demo that generates 19 questions in a member with multiple choice, fill-in-the-blank, and short answer.  We can clone the `MemberA` file that generates these to make a `MemberB` file that has different formats and different preview HTML.

The demo also includes one of several keywords in each question (velocity, mass, vector). 

Thanks @nathanstitt for giving me good code to base this on.

I kind of like that the preview HTML doesn't look great - we will likely get a range of HTML styles.

![image](https://user-images.githubusercontent.com/1001691/44379034-4ea6d580-a4c1-11e8-8d69-4ae3c834ebd6.png)
