### PR TITLE
add fields to JS models for better download schema

### DIFF
--- a/app/javascript/models/assessment.js
+++ b/app/javascript/models/assessment.js
@@ -13,6 +13,8 @@ export default class Assessment extends BaseModel {
   @identifier id;
   @field a15k_identifier;
   @field a15k_version;
+  @field source_identifier;
+  @field source_version;
 
   @belongsTo({ model: Member }) member;
   @hasMany({ model: Variant }) variants;

--- a/app/javascript/models/variant.js
+++ b/app/javascript/models/variant.js
@@ -1,15 +1,16 @@
 import {
-  BaseModel, identifiedBy, field, identifier, hasMany,
+  BaseModel, identifiedBy, field, identifier,
 } from './base';
-import Solution from './solution';
+// import Solution from './solution';
 
 @identifiedBy('variant')
 export default class Variant extends BaseModel {
 
   @identifier id;
+  @field source_identifier;
   @field format_id;
   @field({ type: 'object' }) content;
   @field preview_html;
-  @hasMany({ model: Solution }) solutions;
+  // @hasMany({ model: Solution }) solutions;
 
 }

--- a/app/javascript/models/variant.js
+++ b/app/javascript/models/variant.js
@@ -1,6 +1,7 @@
 import {
   BaseModel, identifiedBy, field, identifier,
 } from './base';
+// not currently exposed
 // import Solution from './solution';
 
 @identifiedBy('variant')
@@ -11,6 +12,7 @@ export default class Variant extends BaseModel {
   @field format_id;
   @field({ type: 'object' }) content;
   @field preview_html;
+  // hidden since we're not currently exposing solutions
   // @hasMany({ model: Solution }) solutions;
 
 }


### PR DESCRIPTION
The download button serializes a JS model from memory instead of pulling data from the API GET endpoint, as such it was missing a few fields.  This PR adds those fields to the JS models so they are in the downloaded JSON (as well as hides solutions).

We should probably change to using the GET endpoint at some point.