### PR TITLE
cast stub flags

### DIFF
--- a/lib/a15k/interactions.rb
+++ b/lib/a15k/interactions.rb
@@ -6,7 +6,9 @@ module A15K
 
     def self.api(stub: Rails.application.secrets.interactions_api[:stub])
       @api ||= (
-        stub ? FakeApi : A15kInteractions::AppsApi.new
+        ActiveAttr::Typecasting::BooleanTypecaster.new.call(stub) ?
+          FakeApi :
+          A15kInteractions::AppsApi.new
       )
     end
 

--- a/lib/a15k/metadata.rb
+++ b/lib/a15k/metadata.rb
@@ -9,7 +9,9 @@ module A15K
   module Metadata
 
     def self.api(stub: Rails.application.secrets.metadata_api[:stub])
-      stub ? FakeApi.new : Api.new
+      ActiveAttr::Typecasting::BooleanTypecaster.new.call(stub) ?
+        FakeApi.new :
+        Api.new
     end
 
   end

--- a/lib/tasks/install_secrets.rake
+++ b/lib/tasks/install_secrets.rake
@@ -70,7 +70,15 @@ end
 
 def deep_populate(hash, keys, value)
   if keys.length == 1
-    hash[keys[0]] = value
+    hash[keys[0]] =
+      case value
+      when "true"
+        true
+      when "false"
+        false
+      else
+        value
+      end
   else
     hash[keys[0]] ||= {}
     deep_populate(hash[keys[0]], keys[1..-1], value)


### PR DESCRIPTION
when installing secrets, convert `"true"` and `"false"` to `true` and `false` in yaml.  As an extra measure, and to handle that environment variables of `false` are read as strings, cast string stub values to boolean.

.env file
```
A15K_METADATA_STUB=false
```

```
irb(main):002:0> puts "uh-oh" if ENV.fetch('A15K_METADATA_STUB', true)
uh-oh
=> nil
```

```
irb(main):003:0> puts "uh-oh" if ActiveAttr::Typecasting::BooleanTypecaster.new.call(ENV.fetch('A15K_METADATA_STUB', true))
=> nil
```