### PR TITLE
unquote booleans when installing secrets

### DIFF
--- a/lib/tasks/install_secrets.rake
+++ b/lib/tasks/install_secrets.rake
@@ -59,7 +59,10 @@ end
 
 def yaml(hash)
   # write the hash as yaml, getting rid of the "---\n" at the front
+  # and undoing the quoting of false and true
   hash.to_yaml[4..-1]
+      .gsub("'false'", "false")
+      .gsub("'true'", "true")
 end
 
 def get_env_var!(name)


### PR DESCRIPTION
In `secrets.yml` will give

```
stub: false
```

instead of

```
stub: 'false'
```